### PR TITLE
Add follow on twitter badge 

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
   <a href="https://www.npmjs.com/package/vue"><img src="https://img.shields.io/npm/v/vue.svg" alt="Version"></a>
   <a href="https://www.npmjs.com/package/vue"><img src="https://img.shields.io/npm/l/vue.svg" alt="License"></a>
   <a href="https://chat.vuejs.org/"><img src="https://img.shields.io/badge/chat-on%20discord-7289da.svg" alt="Chat"></a>
+  <a href="https://twitter.com/intent/follow?screen_name=vuejs"><img src="https://img.shields.io/twitter/follow/vuejs.svg?style=social&label=Follow" alt="Follow on Twitter"></a>
   <br>
   <a href="https://app.saucelabs.com/builds/50f8372d79f743a3b25fb6ca4851ca4c"><img src="https://app.saucelabs.com/buildstatus/vuejs" alt="Build Status"></a>
 </p>


### PR DESCRIPTION
I think it would be nice having a `Follow on Twitter` badge showing the current follower count redirecting to the official Twitter account for `vuejs` :thinking: 

> It looks like this:

[![Twitter](https://img.shields.io/twitter/follow/vuejs.svg?style=social&label=Follow)](https://twitter.com/intent/follow?screen_name=vuejs)