### PR TITLE
fix(types): Allow WatchHandler to be of string type even when used with WatchOptions

### DIFF
--- a/types/options.d.ts
+++ b/types/options.d.ts
@@ -64,7 +64,7 @@ export interface ComponentOptions<
   propsData?: object;
   computed?: Accessors<Computed>;
   methods?: Methods;
-  watch?: Record<string, WatchOptionsWithHandler<any> | WatchHandler<any> | string>;
+  watch?: Record<string, WatchOptionsWithHandler<any> | WatchHandler<any> | (WatchOptionsWithHandler<any> | WatchHandler<any>)[]>;
 
   el?: Element | string;
   template?: string;
@@ -153,7 +153,7 @@ export interface ComputedOptions<T> {
   cache?: boolean;
 }
 
-export type WatchHandler<T> = (val: T, oldVal: T) => void;
+export type WatchHandler<T> = ((val: T, oldVal: T) => void) | string;
 
 export interface WatchOptions {
   deep?: boolean;

--- a/types/test/options-test.ts
+++ b/types/test/options-test.ts
@@ -133,16 +133,27 @@ Vue.component('component', {
     }
   },
   watch: {
-    'a': function(val: number, oldVal: number) {
-      console.log(`new: ${val}, old: ${oldVal}`);
+    a: function (val, oldVal) {
+      console.log('new: %s, old: %s', val, oldVal)
     },
-    'b': 'someMethod',
-    'c': {
-      handler(val, oldVal) {
-        this.a = val
-      },
+    b: 'someMethod',
+    c: {
+      handler: function (val, oldVal) { /* ... */ },
       deep: true
-    }
+    },
+    d: {
+      handler: function (val, oldVal) { /* ... */ },
+      immediate: true
+    },
+    e: [
+      'handle1',
+      function handle2 (val, oldVal) { /* ... */ },
+      {
+        handler: function handle3 (val, oldVal) { /* ... */ },
+        /* ... */
+      }
+    ],
+    'e.f': function (val, oldVal) { /* ... */ }
   },
   el: "#app",
   template: "<div>{{ message }}</div>",


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
